### PR TITLE
fix fetch timeout cause by getStaticProps, show header, sidebar only …

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,3 +1,4 @@
+/*
 "use client"
 import { PackagesProps } from "@/types/packages";
 import { useEffect, useState } from "react";
@@ -40,7 +41,7 @@ const Page = () => {
 
   return (
     <>
-      {/* Start:: Pricing Item */}
+      {// Start:: Pricing Item}
       {
         loading ?
           <div className="w-full min-h-[50vh] flex items-center justify-center">
@@ -58,3 +59,25 @@ const Page = () => {
 }
 
 export default Page;
+
+*/
+
+import { getPackages } from '@/lib/data';
+import { PackagesProps } from "@/types/packages";
+import Packages from "@/components/Pricing/Packages";
+
+async function Page() {
+  const plans = await getPackages();
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6 xl:grid-cols-4 2xl:gap-7.5">
+        {plans.data.map((plan: PackagesProps) => (
+            <Packages key={plan.id} {...plan} />
+        ))}
+      </div>
+
+    </>
+  )
+}
+
+export default Page

--- a/components/Header/DropdownUser.tsx
+++ b/components/Header/DropdownUser.tsx
@@ -1,23 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import {signOut, useSession, getProviders } from "next-auth/react";
+import {signOut, useSession} from "next-auth/react";
 
 const DropdownUser = () => {
   const { data: session } = useSession();
-  const [providers, setProviders] = useState<any>(null);
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const trigger = useRef<any>(null);
   const dropdown = useRef<any>(null);
-
-  useEffect(() => {
-    (async () => {
-      const res = await getProviders();
-      setProviders(res);
-    })();
-  }, []);
 
   // close on click outside
   useEffect(() => {

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -5,11 +5,16 @@ import DropdownNotification from "./DropdownNotification";
 import DropdownUser from "./DropdownUser";
 import Image from "next/image";
 
+import {useSession} from "next-auth/react";
+
 const Header = (props: {
   sidebarOpen: string | boolean | undefined;
   setSidebarOpen: (arg0: boolean) => void;
 }) => {
+  const { data: session } = useSession();
+
   return (
+    session?.user ? (
     <header className="sticky top-0 z-999 flex w-full bg-white drop-shadow-1 dark:bg-boxdark dark:drop-shadow-none">
       <div className="flex flex-grow items-center justify-between px-4 py-4 shadow-2 md:px-6 2xl:px-11">
         <div className="flex items-center gap-2 sm:gap-4 lg:hidden">
@@ -87,6 +92,7 @@ const Header = (props: {
         </div>
       </div>
     </header>
+    ):null
   );
 };
 

--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -4,12 +4,15 @@ import { usePathname } from "next/navigation";
 import SidebarLinkGroup from "./SidebarLinkGroup";
 import Image from "next/image";
 
+import {useSession} from "next-auth/react";
+
 interface SidebarProps {
   sidebarOpen: boolean;
   setSidebarOpen: (arg: boolean) => void;
 }
 
 const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
+  const { data: session } = useSession();
   const pathname = usePathname();
 
   const trigger = useRef<any>(null);
@@ -56,6 +59,7 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
   }, [sidebarExpanded]);
 
   return (
+    session?.user ? (
     <aside
       ref={sidebar}
       className={`absolute left-0 top-0 z-9999 flex h-screen w-72.5 flex-col overflow-y-hidden bg-black bg-sidebar-aside duration-300 ease-linear dark:bg-boxdark lg:static lg:translate-x-0 ${sidebarOpen ? "translate-x-0" : "-translate-x-full"
@@ -208,6 +212,7 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
         {/* <!-- Sidebar Menu --> */}
       </div>
     </aside>
+    ):null
   );
 };
 

--- a/lib/data.tsx
+++ b/lib/data.tsx
@@ -13,6 +13,17 @@ export const checkEmail = async (email?: string) => {
   }
 };
 
+export const getPackages = async () => {
+  try {
+    const url = process.env.API_URL + '/packages?api_key=' + process.env.API_KEY
+    const res = await axios.get(url);
+    const result = res.data;
+    return result.data;
+  } catch (error) {
+    console.log('Error', error);
+  }
+};
+
 export const loginUser = async (data: User) => {
   try {
     const res = await fetch('/api/auth/signin', {


### PR DESCRIPTION
…when login

You should not fetch an internal API route from getStaticProps — instead, you can write the fetch code in API route directly in getStaticProps. https://nextjs.org/docs/basic-features/data-fetching/get-static-props#write-server-side-code-directly